### PR TITLE
Expand password column length

### DIFF
--- a/oauth.ddl
+++ b/oauth.ddl
@@ -92,7 +92,7 @@ CREATE TABLE oauth_scopes (
 
 CREATE TABLE oauth_users (
   username            VARCHAR(80),
-  password            VARCHAR(80),
+  password            VARCHAR(255),
   first_name          VARCHAR(80),
   last_name           VARCHAR(80),
   email               VARCHAR(80),


### PR DESCRIPTION
Quote from [`password_hash`](https://www.php.net/manual/en/function.password-hash.php) PHP help:

> **`PASSWORD_DEFAULT`** - Use the bcrypt algorithm (default as of PHP 5.5.0). Note that this constant is designed to change over time as new and stronger algorithms are added to PHP. For that reason, the length of the result from using this identifier can change over time. Therefore, it is recommended to store the result in a database column that can expand beyond 60 characters (255 characters would be a good choice).

Closes #10